### PR TITLE
feat: add support for CD, refactor class to take input streams as args

### DIFF
--- a/include/minsh.hpp
+++ b/include/minsh.hpp
@@ -13,13 +13,16 @@ namespace minsh {
 	class Minsh {
 		private:
 			std::vector<std::string> history;
+			std::istream& is;
+			std::ostream& os;
 			const std::vector<std::string> splitCommand(std::string str, char sub);
 			int forkNexec(std::vector<std::string>& argList);
 			void executeCommand(int& cp, std::string line, bool& empty);
 			void wait(int childPid);
 		public:
-			Minsh() { };	
-			void process(std::istream& is = std::cin, const std::string& prompt= "∫ ", bool parallel = false);
+			Minsh(std::istream& inIs, std::ostream& inOs) : is(inIs), os(inOs)  { };	
+			Minsh() : is(std::cin), os(std::cout)  { };	
+			void process(const std::string& prompt= "∫ ", bool parallel = false);
 			
 	};
 }

--- a/test/test_minsh.cpp
+++ b/test/test_minsh.cpp
@@ -1,9 +1,20 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <minsh.hpp>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <pwd.h>
 
 using namespace minsh;
 
-TEST_CASE( "First test", "[main]" ) {
-	Minsh m;
+TEST_CASE( "Test changing directories", "[main]" ) {
+	std::stringstream sin, sout;
+	Minsh m(sin, sout);
+	sin << "cd ~/" << std::endl << "exit";
+	m.process();
+	std::string output =  sout.str(); 
+	struct passwd *pw = getpwuid(getuid());
+	const char* home = pw->pw_dir;
+	REQUIRE(output.find(home) != std::string::npos);
 }


### PR DESCRIPTION
- cd works now, uses the chdir call
- cd works with tilde expansions and other typical shell expansions now by utilizing wordexp.h
- Minsh class now takes input and output stream in constructor
- Add one test for cd to home directory in minsh
- Now show working directory in prompt along with username